### PR TITLE
systemd: make pre-start container cleanup deterministic

### DIFF
--- a/templates/systemd/container-socket-proxy.service.j2
+++ b/templates/systemd/container-socket-proxy.service.j2
@@ -18,7 +18,7 @@ DefaultDependencies=no
 [Service]
 Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
-ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ container_socket_proxy_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect {{ container_socket_proxy_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ container_socket_proxy_identifier }}" >&2; exit 1'
+ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ container_socket_proxy_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect --type=container {{ container_socket_proxy_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ container_socket_proxy_identifier }}" >&2; exit 1'
 
 # We cannot use `--read-only` since 0.1.2, because of:
 # > /usr/local/bin/docker-entrypoint.sh: line 18: can't create /usr/local/etc/haproxy/haproxy.cfg: Read-only file system

--- a/templates/systemd/container-socket-proxy.service.j2
+++ b/templates/systemd/container-socket-proxy.service.j2
@@ -18,8 +18,7 @@ DefaultDependencies=no
 [Service]
 Type=simple
 Environment="HOME={{ devture_systemd_docker_base_systemd_unit_home_path }}"
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} stop -t {{ devture_systemd_docker_base_container_stop_grace_time_seconds }} {{ container_socket_proxy_identifier }} 2>/dev/null || true'
-ExecStartPre=-{{ devture_systemd_docker_base_host_command_sh }} -c '{{ devture_systemd_docker_base_host_command_docker }} rm {{ container_socket_proxy_identifier }} 2>/dev/null || true'
+ExecStartPre={{ devture_systemd_docker_base_host_command_sh }} -c 'i=0; while [ "$i" -lt 10 ]; do {{ devture_systemd_docker_base_host_command_docker }} rm -f {{ container_socket_proxy_identifier }} >/dev/null 2>&1 || true; if ! {{ devture_systemd_docker_base_host_command_docker }} inspect {{ container_socket_proxy_identifier }} >/dev/null 2>&1; then exit 0; fi; i=$((i + 1)); sleep 1; done; echo "Failed to remove stale container {{ container_socket_proxy_identifier }}" >&2; exit 1'
 
 # We cannot use `--read-only` since 0.1.2, because of:
 # > /usr/local/bin/docker-entrypoint.sh: line 18: can't create /usr/local/etc/haproxy/haproxy.cfg: Read-only file system


### PR DESCRIPTION
## Problem
Container cleanup was hardened with a bounded `rm -f` loop, but the existence check used generic `docker inspect` matching any object type.

## Root Cause
`docker inspect` without `--type=container` can produce false positives when non-container objects share names.

## Fix
- keep deterministic cleanup loop behavior unchanged
- change cleanup verification to `docker inspect --type=container ...` before `docker create`

## Compatibility
No behavior change for healthy cases; this only tightens stale-container detection semantics.

## Validation
- `pre-commit run --all-files`
- `ansible-lint .` passed
